### PR TITLE
Prohibit possible duplicates for products #18

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 
@@ -22,6 +23,15 @@ func NewApiTest() (app *gin.Engine, router *gin.RouterGroup, conf k4ever.Config)
 
 func PerformRequest(r http.Handler, method, path string) *httptest.ResponseRecorder {
 	req, _ := http.NewRequest(method, path, nil)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func PerformRequestWithBody(r http.Handler, method, path string, body []byte) *httptest.ResponseRecorder {
+	req, _ := http.NewRequest(method, path, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	return w

--- a/internal/api/product.go
+++ b/internal/api/product.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	jwt "github.com/appleboy/gin-jwt"
 	"github.com/freitagsrunde/k4ever-backend/internal/k4ever"
@@ -130,6 +131,10 @@ func createProduct(router *gin.RouterGroup, config k4ever.Config) {
 			return
 		}
 		if err := config.DB().Create(&product).Error; err != nil {
+			if strings.Contains(err.Error(), "UNIQUE") {
+				c.JSON(http.StatusOK, gin.H{"error": err.Error()})
+				return
+			}
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}

--- a/internal/api/product_test.go
+++ b/internal/api/product_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -15,7 +14,38 @@ func TestGetProducts(t *testing.T) {
 
 	result := PerformRequest(app, "GET", "/api/v1")
 
-	fmt.Println(router)
-
 	assert.Equal(t, http.StatusOK, result.Code)
+}
+
+func TestCreateProduct(t *testing.T) {
+	app, router, conf := NewApiTest()
+
+	createProduct(router, conf)
+
+	var json = []byte(`{
+		"name":"Product",
+		"price":1.50
+	}`)
+
+	result := PerformRequestWithBody(app, "POST", "/api/v1", json)
+
+	assert.Equal(t, http.StatusCreated, result.Code)
+
+}
+
+func TestCreateDuplicateProduct(t *testing.T) {
+	app, router, conf := NewApiTest()
+
+	createProduct(router, conf)
+
+	var json = []byte(`{
+		"name":"Product",
+		"price":1.50
+	}`)
+
+	result := PerformRequestWithBody(app, "POST", "/api/v1", json)
+	result2 := PerformRequestWithBody(app, "POST", "/api/v1", json)
+
+	assert.Equal(t, http.StatusCreated, result.Code)
+	assert.Equal(t, http.StatusOK, result2.Code)
 }

--- a/internal/models/product.go
+++ b/internal/models/product.go
@@ -21,7 +21,7 @@ type Product struct {
 	// min: 1
 	//
 	// example: club mate
-	Name string `json:"name" gorm:"not_null"`
+	Name string `json:"name" gorm:"not_null;unique"`
 
 	// The price of the product
 	//
@@ -43,7 +43,7 @@ type Product struct {
 	// The barcode of the product
 	//
 	// required: false
-	Barcode string `json:"barcode"`
+	Barcode string `json:"barcode" gorm:"unique;default: null"`
 
 	// Currently the path to the image (tbi)
 	//


### PR DESCRIPTION
This pull request prohibits product duplicates by name or barcode.

Currently a duplicate error is return with status code 200 and an error message after looking through some popular apis.